### PR TITLE
[FIX] Update atlasreader.py probability threshold and minimum proportion in clusters.csv

### DIFF
--- a/atlasreader/atlasreader.py
+++ b/atlasreader/atlasreader.py
@@ -439,8 +439,7 @@ def read_atlas_cluster(atlastype, cluster, affine, prob_thresh=5):
 
     sortID = np.argsort(percentage)[::-1]
 
-    return [[percentage[s], labels[s]] for s in sortID if
-            percentage[s] >= prob_thresh]
+    return [[percentage[s], labels[s]] for s in sortID]
 
 
 def process_img(stat_img, cluster_extent, voxel_thresh=1.96, direction='both'):


### PR DESCRIPTION
Dear all,

first of all, thanks for this usefull tool! When I used the Harvard Oxford Atlas with a probability threshold of 25, I noticed that the probability threshold is not only used as a probability threshold for the atlas itself but the threshold also determines the minimum proportion of a cluster, which a region has to exceed to be part of the clusters.csv file. For instance a region encompassing 24% of a cluster would not be in the clusters.csv file after a probability threshold of 25 is applied. When changing the code according to the pull request, the region would be part of the clusters.csv file when a probility threshold of 0 or a threshold of 25 is applied. Only the proportion of the region would probably vary slightly, because of the different atlas probabilites used. 
In my mind the atlas probability threshold should not go in hand with the minimum proportion of a region in a certain cluster to be displayed in the clusters.csv file. Do you agree that the change makes sense? Or did I miss something?

Thank you
Anna